### PR TITLE
Breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,55 @@
 # bidirpc
-[![MIT licensed][1]][2] [![Build Status][3]][4] [![Coverage Statusd][5]][6]
 
-[1]: https://img.shields.io/badge/license-MIT-blue.svg
-[2]: LICENSE
-[3]: https://travis-ci.org/zhuyie/bidirpc.svg?branch=master
-[4]: https://travis-ci.org/zhuyie/bidirpc
-[5]: https://codecov.io/gh/zhuyie/bidirpc/branch/master/graph/badge.svg
-[6]: https://codecov.io/gh/zhuyie/bidirpc
+[![GoDoc][1]][2] [![MIT licensed][3]][4] [![Build Status][5]][6] [![Coverage Statusd][7]][8]
+
+[1]: https://godoc.org/github.com/zhuyie/bidirpc?status.svg
+[2]: https://godoc.org/github.com/zhuyie/bidirpc
+[3]: https://img.shields.io/badge/license-MIT-blue.svg
+[4]: LICENSE
+[5]: https://travis-ci.org/zhuyie/bidirpc.svg?branch=master
+[6]: https://travis-ci.org/zhuyie/bidirpc
+[7]: https://codecov.io/gh/zhuyie/bidirpc/branch/master/graph/badge.svg
+[8]: https://codecov.io/gh/zhuyie/bidirpc
 
 bidirpc is a simple bi-direction RPC library.
+
+## Usage
+
+```go
+
+import (
+    "io"
+    "log"
+
+    "github.com/zhuyie/bidirpc"
+)
+
+
+var conn io.ReadWriteCloser
+
+// Create a registry, and register your available services, Service follows
+// net/rpc semantics
+registry := bidirpc.NewRegistry()
+registry.Register(&Service{})
+
+// TODO: Establish your connection before passing it to the session
+
+// Create a new session
+session, err := bidirpc.NewSession(conn, Yin, registry, 0)
+if err != nil {
+	log.Fatal(err)
+}
+// Clean up session resources
+defer func() {
+	if err := session.Close(); err != nil {
+		log.Fatal(err)
+	}
+}()
+
+// Start the event loop, this is a blocking call, so place it in a goroutine
+// if you need to move on.  The call will return when the connection is
+// terminated.
+if err = session.Serve(); err != nil {
+	log.Fatal(err)
+}
+```

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -50,8 +50,8 @@ func init() {
 	registryYin = NewRegistry()
 	registryYin.Register(service)
 	registryYang = NewRegistry()
-	sessionYin, _ = NewSession(connYin, true, registryYin, 0)
-	sessionYang, _ = NewSession(connYang, false, registryYang, 0)
+	sessionYin, _ = NewSession(connYin, Yin, registryYin, 0)
+	sessionYang, _ = NewSession(connYang, Yang, registryYang, 0)
 	go func() {
 		_ = sessionYin.Serve()
 	}()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -35,19 +35,23 @@ func (s *BenchService) EchoString(args StringArgs, reply *StringReply) error {
 }
 
 var (
-	sessionYin  *Session
-	sessionYang *Session
-	client      *rpc.Client
-	server      *rpc.Server
+	sessionYin   *Session
+	sessionYang  *Session
+	registryYin  *Registry
+	registryYang *Registry
+	client       *rpc.Client
+	server       *rpc.Server
 )
 
 func init() {
 	service := &BenchService{}
 
 	connYin, connYang := net.Pipe()
-	sessionYin, _ = NewSession(connYin, true, 0)
-	sessionYang, _ = NewSession(connYang, false, 0)
-	sessionYin.Register(service)
+	registryYin = NewRegistry()
+	registryYin.Register(service)
+	registryYang = NewRegistry()
+	sessionYin, _ = NewSession(connYin, true, registryYin, 0)
+	sessionYang, _ = NewSession(connYang, false, registryYang, 0)
 	go func() {
 		_ = sessionYin.Serve()
 	}()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -48,6 +48,12 @@ func init() {
 	sessionYin, _ = NewSession(connYin, true, 0)
 	sessionYang, _ = NewSession(connYang, false, 0)
 	sessionYin.Register(service)
+	go func() {
+		_ = sessionYin.Serve()
+	}()
+	go func() {
+		_ = sessionYang.Serve()
+	}()
 
 	connServer, connClient := net.Pipe()
 	client = rpc.NewClient(connClient)

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,33 @@
+package bidirpc
+
+import "net/rpc"
+
+// Registry provides the available RPC receivers
+type Registry struct {
+	server *rpc.Server
+}
+
+// Register publishes in the server the set of methods of the
+// receiver value that satisfy the following conditions:
+//  - exported method of exported type
+//  - two arguments, both of exported type
+//  - the second argument is a pointer
+//  - one return value, of type error
+// It returns an error if the receiver is not an exported type or has
+// no suitable methods. It also logs the error using package log.
+// The client accesses each method using a string of the form "Type.Method",
+// where Type is the receiver's concrete type.
+func (r *Registry) Register(rcvr interface{}) error {
+	return r.server.Register(rcvr)
+}
+
+// RegisterName is like Register but uses the provided name for the type
+// instead of the receiver's concrete type.
+func (r *Registry) RegisterName(name string, rcvr interface{}) error {
+	return r.server.RegisterName(name, rcvr)
+}
+
+// NewRegistry instantiates a Registry
+func NewRegistry() *Registry {
+	return &Registry{server: rpc.NewServer()}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -45,11 +45,11 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("Register error: %v", err)
 	}
 
-	sessionYin, err := NewSession(connYin, true, registryYin, 0)
+	sessionYin, err := NewSession(connYin, Yin, registryYin, 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
-	sessionYang, err := NewSession(connYang, false, registryYang, 0)
+	sessionYang, err := NewSession(connYang, Yang, registryYang, 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestReadError(t *testing.T) {
 	connYin, connYang := net.Pipe()
 	connYang.Close()
 
-	sessionYin, err := NewSession(connYin, true, NewRegistry(), 0)
+	sessionYin, err := NewSession(connYin, Yin, NewRegistry(), 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestWriteError(t *testing.T) {
 	connYin, _ := net.Pipe()
 	connYin.Close()
 
-	sessionYin, err := NewSession(connYin, true, NewRegistry(), 0)
+	sessionYin, err := NewSession(connYin, Yin, NewRegistry(), 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestWriteError2(t *testing.T) {
 	_, connYang := net.Pipe()
 	connYang.Close()
 
-	sessionYang, err := NewSession(connYang, false, NewRegistry(), 0)
+	sessionYang, err := NewSession(connYang, Yang, NewRegistry(), 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestWriteError2(t *testing.T) {
 func TestReadInvalidHeader(t *testing.T) {
 	connYin, connYang := net.Pipe()
 
-	sessionYin, err := NewSession(connYin, true, NewRegistry(), 0)
+	sessionYin, err := NewSession(connYin, Yin, NewRegistry(), 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestReadInvalidHeader(t *testing.T) {
 func TestReadBodyError(t *testing.T) {
 	connYin, connYang := net.Pipe()
 
-	sessionYin, err := NewSession(connYin, true, NewRegistry(), 0)
+	sessionYin, err := NewSession(connYin, Yin, NewRegistry(), 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestReadBodyError(t *testing.T) {
 	}()
 
 	var header [4]byte
-	encodeHeader(header[:], streamTypeYang, 10)
+	encodeHeader(header[:], byte(Yang), 10)
 	connYang.Write(header[:])
 	connYang.Close()
 
@@ -282,11 +282,11 @@ func TestConcurrent(t *testing.T) {
 		t.Fatalf("Register error: %v", err)
 	}
 
-	sessionYin, err := NewSession(connYin, true, registryYin, 0)
+	sessionYin, err := NewSession(connYin, Yin, registryYin, 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}
-	sessionYang, err := NewSession(connYang, false, registryYang, 0)
+	sessionYang, err := NewSession(connYang, Yang, registryYang, 0)
 	if err != nil {
 		t.Fatalf("NewSession error: %v", err)
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -2,6 +2,8 @@ package bidirpc
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -342,4 +344,33 @@ func TestConcurrent(t *testing.T) {
 	sessionYin.Close()
 	sessionYang.Close()
 	sessionWait.Wait()
+}
+
+func ExampleSession() {
+	var conn io.ReadWriteCloser
+
+	// Create a registry, and register your available services
+	registry := NewRegistry()
+	registry.Register(&Service{})
+
+	// TODO: Establish your connection before passing it to the session
+
+	// Create a new session
+	session, err := NewSession(conn, Yin, registry, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Clean up session resources
+	defer func() {
+		if err := session.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Start the event loop, this is a blocking call, so place it in a goroutine
+	// if you need to move on.  The call will return when the connection is
+	// terminated.
+	if err = session.Serve(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/stream.go
+++ b/stream.go
@@ -42,7 +42,9 @@ func (s *stream) Read(p []byte) (n int, err error) {
 func (s *stream) Write(p []byte) (n int, err error) {
 	if s.writer.Len() == 0 {
 		var dummyHeader [4]byte
-		s.writer.Write(dummyHeader[:])
+		if n, err := s.writer.Write(dummyHeader[:]); err != nil {
+			return n, err
+		}
 	}
 	return s.writer.Write(p)
 }


### PR DESCRIPTION
- Allow blocking on event loop (requires calling of `Session.Serve()` to start loop)
- Extract `Registry` from `Session` to allow pre-registration
- Export `Yin`/`Yang` for `NewSession()` argument.

Fixes #1